### PR TITLE
Fix main process crash when videoDetails is undefined

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1667,6 +1667,8 @@ app.on("ready", async () => {
 
   ipcMain.on("ytmView:videoDataChanged", (event, videoDetails, playlistId, album, likeStatus, hasFullMetadata) => {
     if (event.sender !== ytmView.webContents) return;
+    // The player response can lack video details (no video loaded yet or an ad is playing)
+    if (!videoDetails || !videoDetails.videoId) return;
 
     lastVideoId = videoDetails.videoId;
     lastPlaylistId = playlistId;

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -325,7 +325,10 @@ window.addEventListener("load", async () => {
       (
         await webFrame.executeJavaScript(`
           (function() {
-            window.ytmd.sendVideoData(document.querySelector("ytmusic-app-layout>ytmusic-player-bar").playerApi.getPlayerResponse().videoDetails, document.querySelector("ytmusic-app-layout>ytmusic-player-bar").playerApi.getPlaylistId());
+            const videoDetails = document.querySelector("ytmusic-app-layout>ytmusic-player-bar").playerApi.getPlayerResponse()?.videoDetails;
+            if (videoDetails) {
+              window.ytmd.sendVideoData(videoDetails, document.querySelector("ytmusic-app-layout>ytmusic-player-bar").playerApi.getPlaylistId());
+            }
           })
         `)
       )();

--- a/src/renderer/ytmview/scripts/hookplayerapievents.script.js
+++ b/src/renderer/ytmview/scripts/hookplayerapievents.script.js
@@ -26,7 +26,8 @@
   });
   document.querySelector("ytmusic-app-layout>ytmusic-player-bar").playerApi.addEventListener("onVideoDataChange", event => {
     if (event.playertype === 1 && (event.type === "dataloaded" || event.type === "dataupdated")) {
-      let videoDetails = document.querySelector("ytmusic-app-layout>ytmusic-player-bar").playerApi.getPlayerResponse().videoDetails;
+      let videoDetails = document.querySelector("ytmusic-app-layout>ytmusic-player-bar").playerApi.getPlayerResponse()?.videoDetails;
+      if (!videoDetails) return;
       let playlistId = document.querySelector("ytmusic-app-layout>ytmusic-player-bar").playerApi.getPlaylistId();
       let album = null;
       let hasFullMetadata = false;


### PR DESCRIPTION
## Problem

The app crashes with the following error (app 2.0.11, Electron 40.4.0, Windows 11):

```
TypeError: Cannot read properties of undefined (reading 'videoId')
    at IpcMainImpl.<anonymous> (.vite/main/index.js:926:6059)
```

The `ytmView:videoDataChanged` IPC handler in `src/main/index.ts` reads `videoDetails.videoId` without checking that `videoDetails` exists. The YTM player API can return a player response with no `videoDetails` — typically when no video has loaded yet or while an ad is playing — and the renderer forwards `undefined` to the main process, which then crashes.

## Fix

- `src/main/index.ts`: guard the `ytmView:videoDataChanged` handler — ignore the event when `videoDetails` or its `videoId` is missing. `lastVideoId`/`lastPlaylistId` (used for "continue where you left off") keep their last good values.
- `src/renderer/ytmview/preload.ts`: the navigate-default path now skips `sendVideoData` when the player response has no video details.
- `src/renderer/ytmview/scripts/hookplayerapievents.script.js`: same guard in the `onVideoDataChange` hook (also prevents a renderer-side crash at the `likeStatus` lookup a few lines below).

Tested locally on Windows 11: built with `yarn make` and confirmed the crash no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)